### PR TITLE
Potential Fix for updating posts?

### DIFF
--- a/routes/posts-router.js
+++ b/routes/posts-router.js
@@ -84,7 +84,7 @@ router.put("/:id", restricted, (req, res) => {
   const { id } = req.params;
   const changes = req.body;
 
-  if (!changes.item_name) {
+  if (!changes.couple_name) {
     res.status(400).json({
       error: "Please provide a name for the post."
     });


### PR DESCRIPTION
When the FE webpage used axios.put to update an existing event, the server checks to see if a property called `item_name` exists in our event. The issue here is, the initial event doesn't even have a property called `item_name`.
The closest thing here would be `couple_name`, so I switched out the name here. I think this could fix the current error we're getting("Please provide a name for the post.") when updating a post.